### PR TITLE
Changed base url to use https

### DIFF
--- a/wanikani.js
+++ b/wanikani.js
@@ -139,7 +139,7 @@
 var wanikani = (function(window, document) {
     "use strict";
     var users = {};
-    var url_base = 'http://www.wanikani.com';
+    var url_base = 'https://www.wanikani.com';
     var api_path = 'api/v1.4/user';
     var getURI = function() {
         var args = Array.prototype.slice.call(arguments, 0);


### PR DESCRIPTION
I think Chrome extensions can't use non-secure sources. Using http in the `content_security_policy` section of an extension `manifest.json` results in an error when loading: `Ignored insecure CSP value "http://www.wanikani.com/" in directive 'script-src'.`